### PR TITLE
Typograpghy tweaks

### DIFF
--- a/WinUIGallery/ControlPages/Typography.xaml
+++ b/WinUIGallery/ControlPages/Typography.xaml
@@ -1,121 +1,116 @@
 <!--
-//*********************************************************
-//
-// Copyright (c) Microsoft. All rights reserved.
-// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
-// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
-// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
-// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
-//
-//*********************************************************
+    //*********************************************************
+    //
+    // Copyright (c) Microsoft. All rights reserved.
+    // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+    // ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+    // IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+    // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+    //
+    //*********************************************************
 -->
-    
+
 <Page
     x:Class="AppUIBasics.ControlPages.TypographyPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:AppUIBasics"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:AppUIBasics"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:controls="using:WinUIGallery.DesktopWap.Controls"
     x:Name="compactPage"
     mc:Ignorable="d">
 
     <Grid>
-        <local:ControlExample x:Name="Example1" HeaderText="">
+        <local:ControlExample x:Name="Example1" HeaderText="" XamlSource="Typography/TypographySample_xaml.txt">
             <StackPanel Orientation="Vertical">
-                <Canvas Height="450" >
-                    <Image Source="/Assets/typography.png" Height="450" Canvas.ZIndex="0"/>
+                <Canvas Height="450">
+                    <Image
+                        Height="450"
+                        Canvas.ZIndex="0"
+                        Source="/Assets/typography.png" />
 
-                    <Button x:Name="ShowTypographyButton1" Canvas.ZIndex="1" Canvas.Left="150" Canvas.Top="120"
+                    <Button
+                        x:Name="ShowTypographyButton1"
+                        Canvas.Left="150"
+                        Canvas.Top="120"
+                        Padding="4"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
                         AutomationProperties.Name="Show typography"
-                        ToolTipService.ToolTip="Display" VerticalAlignment="Top"
-                        HorizontalAlignment="Right" Click="TestButtonClick1" Padding="4">
-                        <FontIcon Glyph="&#xE946;" FontSize="16"/>
+                        Canvas.ZIndex="1"
+                        Click="TestButtonClick1">
+                        <ToolTipService.ToolTip>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Display"/>
+                                <Button Content="Text"/>
+                            </StackPanel>
+                        </ToolTipService.ToolTip>
+                        <FontIcon FontSize="16" Glyph="&#xE946;" />
                     </Button>
-                    <TeachingTip x:Name="ShowTypographyInfoTooltip1" Target="{x:Bind ShowTypographyButton1}" Title="Display"/>
+                    <TeachingTip
+                        x:Name="ShowTypographyInfoTooltip1"
+                        Title="Display"
+                        Target="{x:Bind ShowTypographyButton1}" />
 
-                    <Button x:Name="ShowTypographyButton2" Canvas.ZIndex="1" Canvas.Left="650" Canvas.Top="60"
+                    <Button
+                        x:Name="ShowTypographyButton2"
+                        Canvas.Left="650"
+                        Canvas.Top="60"
+                        Padding="4"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
                         AutomationProperties.Name="Show typography"
-                        ToolTipService.ToolTip="Caption" VerticalAlignment="Top"
-                        HorizontalAlignment="Right" Click="TestButtonClick2" Padding="4">
-                        <FontIcon Glyph="&#xE946;" FontSize="16"/>
+                        Canvas.ZIndex="1"
+                        Click="TestButtonClick2"
+                        ToolTipService.ToolTip="Caption">
+                        <FontIcon FontSize="16" Glyph="&#xE946;" />
                     </Button>
-                    <TeachingTip x:Name="ShowTypographyInfoTooltip2" Target="{x:Bind ShowTypographyButton2}" Title="Caption"/>
+                    <TeachingTip
+                        x:Name="ShowTypographyInfoTooltip2"
+                        Title="Caption"
+                        Target="{x:Bind ShowTypographyButton2}" />
 
-                    <Button x:Name="ShowTypographyButton3" Canvas.ZIndex="1" Canvas.Left="190" Canvas.Top="280"
+                    <Button
+                        x:Name="ShowTypographyButton3"
+                        Canvas.Left="190"
+                        Canvas.Top="280"
+                        Padding="4"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
                         AutomationProperties.Name="Show typography"
-                        ToolTipService.ToolTip="Body" VerticalAlignment="Top"
-                        HorizontalAlignment="Right" Click="TestButtonClick3" Padding="4">
-                        <FontIcon Glyph="&#xE946;" FontSize="16"/>
+                        Canvas.ZIndex="1"
+                        Click="TestButtonClick3"
+                        ToolTipService.ToolTip="Body">
+                        <FontIcon FontSize="16" Glyph="&#xE946;" />
                     </Button>
-                    <TeachingTip x:Name="ShowTypographyInfoTooltip3" Target="{x:Bind ShowTypographyButton3}" Title="Body"/>
+                    <TeachingTip
+                        x:Name="ShowTypographyInfoTooltip3"
+                        Title="Body"
+                        Target="{x:Bind ShowTypographyButton3}" />
 
                 </Canvas>
-                <Grid Height="600" Width="740">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="5*"/>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="2.5*"/>
-                        <ColumnDefinition Width="3*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="*"/>
-                        <RowDefinition Height="1.2*"/>
-                        <RowDefinition Height="1.7*"/>
-                    </Grid.RowDefinitions>
-                    <Border Grid.Row="1" Grid.ColumnSpan="4" Background="#FFFFFF" CornerRadius="4"/>
-                    <Border Grid.Row="3" Grid.ColumnSpan="4" Background="#FFFFFF" CornerRadius="4"/>
-                    <Border Grid.Row="5" Grid.ColumnSpan="4" Background="#FFFFFF" CornerRadius="4"/>
-                    <Border Grid.Row="7" Grid.ColumnSpan="4" Background="#FFFFFF" CornerRadius="4"/>
-
-                    <TextBlock Text="Example" Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="14" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Caption" Grid.Row="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource CaptionTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Body" Grid.Row="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Body Strong" Grid.Row="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyStrongTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Subtitle" Grid.Row="4" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource SubtitleTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Title" Grid.Row="5" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource TitleTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Title Large" Grid.Row="6" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource TitleLargeTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Display" Grid.Row="7" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource DisplayTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-
-                    <TextBlock Text="Weight" Grid.Column="1" Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="14" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="400" Grid.Row="1" Grid.Column="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="400" Grid.Row="2" Grid.Column="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="600" Grid.Row="3" Grid.Column="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="600" Grid.Row="4" Grid.Column="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="600" Grid.Row="5" Grid.Column="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="600" Grid.Row="6" Grid.Column="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="600" Grid.Row="7" Grid.Column="1" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-
-                    <TextBlock Text="Variable Font" Grid.Column="2" Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="14" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Small" Grid.Row="1" Grid.Column="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Text" Grid.Row="2" Grid.Column="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Text, Semibold" Grid.Row="3" Grid.Column="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Display, Semibold" Grid.Row="4" Grid.Column="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Display, Semibold" Grid.Row="5" Grid.Column="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Display, Semibold" Grid.Row="6" Grid.Column="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="Display, Semibold" Grid.Row="7" Grid.Column="2" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-
-                    <TextBlock Text="Size/Line Height (72PPI)" Grid.Column="3" Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="14" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="12/16 epx" Grid.Row="1" Grid.Column="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="14/20 epx" Grid.Row="2" Grid.Column="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="14/20 epx" Grid.Row="3" Grid.Column="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="20/28 epx" Grid.Row="4" Grid.Column="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="28/36 epx" Grid.Row="5" Grid.Column="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="40/52 epx" Grid.Row="6" Grid.Column="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    <TextBlock Text="68/92 epx" Grid.Row="7" Grid.Column="3" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="20,0,0,0"/>
-
+                <Grid Margin="0,48,0,24">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="308" />
+                    <ColumnDefinition Width="68" />
+                    <ColumnDefinition Width="156" />
+                    <ColumnDefinition Width="108" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                    <TextBlock Text="Example" Margin="24,0,0,0" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="Weight" Grid.Column="1" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="Variable Font" Grid.Column="2" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="Size / Line height"  Grid.Column="3" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="Style" Grid.Column="4" Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                 </Grid>
+                <controls:TypographyControl Example="Caption" Weight="400" VariableFont="Small, Regular" SizeLinHeight="12/16 epx" ExampleStyle="{StaticResource CaptionTextBlockStyle}" ResourceName="CaptionTextBlockStyle" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"/>
+                <controls:TypographyControl Example="Body" Weight="400" VariableFont="Text, Regular" SizeLinHeight="14/20 epx" ExampleStyle="{StaticResource BodyTextBlockStyle}" ResourceName="BodyTextBlockStyle"/>
+                <controls:TypographyControl Example="Body Strong" Weight="600" VariableFont="Text, SemiBold" SizeLinHeight="14/20 epx" ExampleStyle="{StaticResource BodyStrongTextBlockStyle}" ResourceName="BodyStrongTextBlockStyle" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"/>
+                <controls:TypographyControl Example="Subtitle" Weight="600" VariableFont="Display, SemiBold" SizeLinHeight="20/28 epx" ExampleStyle="{StaticResource SubtitleTextBlockStyle}" ResourceName="SubtitleTextBlockStyle" Height="76"/>
+                <controls:TypographyControl Example="Title" Weight="600" VariableFont="Display, SemiBold" SizeLinHeight="28/36 epx" ExampleStyle="{StaticResource TitleTextBlockStyle}" ResourceName="TitleTextBlockStyle" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" Height="86"/>
+                <controls:TypographyControl Example="Title Large" Weight="600" VariableFont="Display, SemiBold" SizeLinHeight="40/52 epx" ExampleStyle="{StaticResource TitleLargeTextBlockStyle}" ResourceName="TitleLargeTextBlockStyle" Height="98"/>
+                <controls:TypographyControl Example="Display" Weight="600" VariableFont="Display, SemiBold" SizeLinHeight="68/92 epx" ExampleStyle="{StaticResource DisplayTextBlockStyle}" ResourceName="DisplayTextBlockStyle" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" Height="106" />
             </StackPanel>
-            <local:ControlExample.Xaml>
-                <x:String>
-                    &lt;Image Source="/Assets/SampleMedia/treetops.jpg" Height="100" /&gt;
-                </x:String>
-            </local:ControlExample.Xaml>
         </local:ControlExample>
     </Grid>
 </Page>

--- a/WinUIGallery/ControlPages/Typography.xaml.cs
+++ b/WinUIGallery/ControlPages/Typography.xaml.cs
@@ -2,6 +2,8 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
 using AppUIBasics.SamplePages;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 namespace AppUIBasics.ControlPages
 {

--- a/WinUIGallery/ControlPagesSampleCode/Typography/TypographySample_xaml.txt
+++ b/WinUIGallery/ControlPagesSampleCode/Typography/TypographySample_xaml.txt
@@ -1,0 +1,7 @@
+﻿<TextBlock Text="Caption" Style="{StaticResource CaptionTextBlockStyle}"/>
+<TextBlock Text="Body" Style="{StaticResource BodyTextBlockStyle}"/>
+<TextBlock Text="Body Strong" Style="{StaticResource BodyStrongTextBlockStyle}"/>
+<TextBlock Text="Subtitle" Style="{StaticResource SubtitleTextBlockStyle}"/>
+<TextBlock Text="Title" Style="{StaticResource TitleTextBlockStyle}"/>
+<TextBlock Text="Title Large" Style="{StaticResource TitleLargeTextBlockStyle}"/>
+<TextBlock Text="Display" Style="{StaticResource DisplayTextBlockStyle}"/>

--- a/WinUIGallery/Controls/DesignGuidance/TypographyControl.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/TypographyControl.xaml
@@ -1,0 +1,163 @@
+<!--  Copyright (c) Microsoft Corporation and Contributors.  -->
+<!--  Licensed under the MIT License.  -->
+
+<UserControl
+    x:Class="WinUIGallery.DesktopWap.Controls.TypographyControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WinUIGallery.DesktopWap.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <Style x:Key="SubtleButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{ThemeResource SubtleFillColorTransparent}" />
+            <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
+            <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimary}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+            <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+            <Setter Property="FocusVisualMargin" Value="-3" />
+            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <ContentPresenter
+                            x:Name="ContentPresenter"
+                            Padding="{TemplateBinding Padding}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            AnimatedIcon.State="Normal"
+                            AutomationProperties.AccessibilityView="Raw"
+                            Background="{TemplateBinding Background}"
+                            BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            ContentTransitions="{TemplateBinding ContentTransitions}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                            <ContentPresenter.BackgroundTransition>
+                                <BrushTransition Duration="0:0:0.083" />
+                            </ContentPresenter.BackgroundTransition>
+
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="PointerOver">
+                                        <Storyboard>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleFillColorSecondary}" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorPrimary}" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                        <VisualState.Setters>
+                                            <Setter Target="ContentPresenter.(AnimatedIcon.State)" Value="PointerOver" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+
+                                    <VisualState x:Name="Pressed">
+                                        <Storyboard>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleFillColorTertiary}" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorSecondary}" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                        <VisualState.Setters>
+                                            <Setter Target="ContentPresenter.(AnimatedIcon.State)" Value="Pressed" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+
+                                    <VisualState x:Name="Disabled">
+                                        <Storyboard>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ControlFillColorDisabled}" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorDisabled}" />
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                        <VisualState.Setters>
+                                            <!--  DisabledVisual Should be handled by the control, not the animated icon.  -->
+                                            <Setter Target="ContentPresenter.(AnimatedIcon.State)" Value="Normal" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+                        </ContentPresenter>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+    <Grid
+        MinHeight="68"
+        PointerEntered="Grid_PointerEntered"
+        PointerExited="Grid_PointerExited">
+        <Grid
+            Padding="{x:Bind Padding, Mode=OneWay}"
+            Background="{x:Bind Background}"
+            CornerRadius="{ThemeResource ControlCornerRadius}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="308" />
+                <ColumnDefinition Width="68" />
+                <ColumnDefinition Width="156" />
+                <ColumnDefinition Width="108" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock
+                Margin="24,0,0,0"
+                VerticalAlignment="Center"
+                Style="{x:Bind ExampleStyle}"
+                Text="{x:Bind Example}" />
+            <TextBlock
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                Text="{x:Bind Weight}" />
+            <TextBlock
+                Grid.Column="2"
+                VerticalAlignment="Center"
+                Text="{x:Bind VariableFont}" />
+            <TextBlock
+                Grid.Column="3"
+                VerticalAlignment="Center"
+                Text="{x:Bind SizeLinHeight}" />
+
+            <StackPanel
+                Grid.Column="4"
+                Height="48"
+                VerticalAlignment="Center"
+                Orientation="Horizontal">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    IsTextSelectionEnabled="True"
+                    Text="{x:Bind ResourceName}" />
+                <Grid
+                    Width="36"
+                    Height="36"
+                    Margin="4,2,8,0">
+                    <Button
+                        x:Name="CopyToClipboardButton"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        AutomationProperties.Name="Copy Style to clipboard"
+                        Click="CopyToClipboardButton_Click"
+                        Content="&#xE16F;"
+                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                        Style="{StaticResource SubtleButtonStyle}"
+                        ToolTipService.ToolTip="Copy Style to clipboard"
+                        Visibility="Collapsed" />
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/WinUIGallery/Controls/DesignGuidance/TypographyControl.xaml.cs
+++ b/WinUIGallery/Controls/DesignGuidance/TypographyControl.xaml.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WinUIGallery.DesktopWap.Controls
+{
+    public sealed partial class TypographyControl : UserControl
+    {
+        public TypographyControl()
+        {
+            this.InitializeComponent();
+        }
+
+        public static readonly DependencyProperty ExampleProperty = DependencyProperty.Register(nameof(Example), typeof(string), typeof(TypographyControl), new PropertyMetadata(""));
+
+        public string Example
+        {
+            get => (string)GetValue(ExampleProperty);
+            set => SetValue(ExampleProperty, value);
+        }
+
+        public static readonly DependencyProperty WeightProperty = DependencyProperty.Register(nameof(Weight), typeof(string), typeof(TypographyControl), new PropertyMetadata(""));
+
+        public string Weight
+        {
+            get => (string)GetValue(WeightProperty);
+            set => SetValue(WeightProperty, value);
+        }
+
+        public static readonly DependencyProperty VariableFontProperty = DependencyProperty.Register(nameof(VariableFont), typeof(string), typeof(TypographyControl), new PropertyMetadata(""));
+
+        public string VariableFont
+        {
+            get => (string)GetValue(VariableFontProperty);
+            set => SetValue(VariableFontProperty, value);
+        }
+
+        public static readonly DependencyProperty SizeLinHeightProperty = DependencyProperty.Register(nameof(SizeLinHeight), typeof(string), typeof(TypographyControl), new PropertyMetadata(""));
+
+        public string SizeLinHeight
+        {
+            get => (string)GetValue(SizeLinHeightProperty);
+            set => SetValue(SizeLinHeightProperty, value);
+        }
+
+        public static readonly DependencyProperty ExampleStyleProperty = DependencyProperty.Register(nameof(ExampleStyleProperty), typeof(Style), typeof(TypographyControl), new PropertyMetadata(null));
+
+        public Style ExampleStyle
+        {
+            get => (Style)GetValue(ExampleStyleProperty);
+            set => SetValue(ExampleStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty ResourceNameProperty = DependencyProperty.Register(nameof(ExampleStyleProperty), typeof(string), typeof(TypographyControl), new PropertyMetadata(null));
+
+        public string ResourceName
+        {
+            get => (string)GetValue(ResourceNameProperty);
+            set => SetValue(ResourceNameProperty, value);
+        }
+
+        private void Grid_PointerEntered(object sender, PointerRoutedEventArgs e)
+        {
+            CopyToClipboardButton.Visibility = Visibility.Visible;
+        }
+
+        private void Grid_PointerExited(object sender, PointerRoutedEventArgs e)
+        {
+            CopyToClipboardButton.Visibility = Visibility.Collapsed;
+        }
+
+        private void CopyToClipboardButton_Click(object sender, RoutedEventArgs e)
+        {
+            DataPackage package = new DataPackage();
+            package.SetText(ResourceName);
+            Clipboard.SetContent(package);
+        }
+    }
+}

--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -21,6 +21,41 @@
       "Items": []
     },
     {
+      "UniqueId": "DesignGuidance",
+      "Title": "Design guidance",
+      "ApiNamespace": "",
+      "Subtitle": "",
+      "ImagePath": "",
+      "ImageIconPath": "",
+      "Description": "",
+      "Items": [
+        {
+          "UniqueId": "Typography",
+          "Title": "Typography",
+          "ApiNamespace": "Microsoft.UI.Xaml",
+          "Subtitle": "Typography helps provide structure and hierarchy to UI.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/TitleBar.png",
+          "ImageIconPath": "ms-appx:///Assets/ControlIcons/DefaultIcon.png",
+          "Description": "Typography helps provide structure and hierarchy to UI. Hover over the example below to view and copy text styles.",
+          "Content": "<p>Look at the <i>Typography.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "IsNew": false,
+          "IsUpdated": true,
+          "Docs": [
+            {
+              "Title": "TextBlock - API",
+              "Uri": "https://learn.microsoft.com/en-us/windows/apps/design/controls/text-block"
+            },
+            {
+              "Title": "Guidelines",
+              "Uri": "https://learn.microsoft.com/en-us/windows/apps/design/signature-experiences/typography"
+            }
+          ],
+          "RelatedControls": [
+          ]
+        }
+      ]
+    },
+    {
       "UniqueId": "MenusAndToolbars",
       "Title": "Menus and Toolbars",
       "ApiNamespace": "",
@@ -2821,30 +2856,6 @@
           "ImageIconPath": "ms-appx:///Assets/ControlIcons/DefaultIcon.png",
           "Description": "This sample shows how to use a custom UIElement as titlebar for app's window.",
           "Content": "<p>Look at the <i>TitleBarPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
-          "IsNew": false,
-          "IsUpdated": true,
-          "Docs": [
-            {
-              "Title": "TitleBar - API",
-              "Uri": "https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window.extendscontentintotitlebar"
-            },
-            {
-              "Title": "Guidelines",
-              "Uri": "https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window"
-            }
-          ],
-          "RelatedControls": [
-          ]
-        },
-        {
-          "UniqueId": "Typography",
-          "Title": "Typography",
-          "ApiNamespace": "Microsoft.UI.Xaml",
-          "Subtitle": "Typography helps provide structure and hierarchy to UI.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/TitleBar.png",
-          "ImageIconPath": "ms-appx:///Assets/ControlIcons/DefaultIcon.png",
-          "Description": "Typography helps provide structure and hierarchy to UI. Hover over the example below to view and copy text styles.",
-          "Content": "<p>Look at the <i>Typography.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "IsNew": false,
           "IsUpdated": true,
           "Docs": [

--- a/WinUIGallery/DesignGuidancePage.xaml
+++ b/WinUIGallery/DesignGuidancePage.xaml
@@ -1,0 +1,16 @@
+<!-- Copyright (c) Microsoft Corporation and Contributors. -->
+<!-- Licensed under the MIT License. -->
+
+<Page
+    x:Class="WinUIGallery.DesktopWap.DesignGuidancePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:WinUIGallery.DesktopWap"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+
+    </Grid>
+</Page>

--- a/WinUIGallery/DesignGuidancePage.xaml.cs
+++ b/WinUIGallery/DesignGuidancePage.xaml.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WinUIGallery.DesktopWap
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class DesignGuidancePage : Page
+    {
+        public DesignGuidancePage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -32,6 +32,7 @@ using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using WinUIGallery.DesktopWap;
 
 namespace AppUIBasics
 {
@@ -44,6 +45,7 @@ namespace AppUIBasics
         private bool _isKeyboardConnected;
         private Microsoft.UI.Xaml.Controls.NavigationViewItem _allControlsMenuItem;
         private Microsoft.UI.Xaml.Controls.NavigationViewItem _newControlsMenuItem;
+        private Microsoft.UI.Xaml.Controls.NavigationViewItem _designGuidanceMenuItem;
 
         public static NavigationRootPage GetForElement(object obj)
         {
@@ -222,16 +224,23 @@ namespace AppUIBasics
                 {
                     this._newControlsMenuItem = itemGroup;
                 }
+                else if (group.UniqueId == "DesignGuidance")
+                {
+                    this._designGuidanceMenuItem = itemGroup;
+                }
             }
 
             // Move "What's New" and "All Controls" to the top of the NavigationView
             NavigationViewControl.MenuItems.Remove(_allControlsMenuItem);
             NavigationViewControl.MenuItems.Remove(_newControlsMenuItem);
+            NavigationViewControl.MenuItems.Remove(_designGuidanceMenuItem);
+            ;
             NavigationViewControl.MenuItems.Insert(0, _allControlsMenuItem);
+            NavigationViewControl.MenuItems.Insert(0, _designGuidanceMenuItem);
             NavigationViewControl.MenuItems.Insert(0, _newControlsMenuItem);
 
             // Separate the All/New items from the rest of the categories.
-            NavigationViewControl.MenuItems.Insert(2, new Microsoft.UI.Xaml.Controls.NavigationViewItemSeparator());
+            NavigationViewControl.MenuItems.Insert(3, new Microsoft.UI.Xaml.Controls.NavigationViewItemSeparator());
 
             _newControlsMenuItem.Loaded += OnNewControlsMenuItemLoaded;
         }
@@ -324,6 +333,13 @@ namespace AppUIBasics
                     if (rootFrame.CurrentSourcePageType != typeof(NewControlsPage))
                     {
                         Navigate(typeof(NewControlsPage));
+                    }
+                }
+                else if (selectedItem == _designGuidanceMenuItem)
+                {
+                    if (rootFrame.CurrentSourcePageType != typeof(DesignGuidancePage))
+                    {
+                        Navigate(typeof(DesignGuidancePage));
                     }
                 }
                 else

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -81,9 +81,20 @@
     <Content Remove="@(Content)" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="ControlPagesSampleCode\Typography\TypographySample_xaml.txt" />
     <None Remove="ControlPages\LinePage.xaml" />
     <None Remove="ControlPages\ShapePage.xaml" />
     <None Remove="ControlPages\Typography.xaml" />
+    <None Remove="Controls\DesignGuidance\TypographyControl.xaml" />
+    <None Remove="DesignGuidancePage.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ControlPagesSampleCode\Typography\TypographySample_xaml.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="DesignGuidancePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="ControlPages\Typography.xaml">
@@ -95,6 +106,11 @@
     </Page>
     <Page Update="ControlPages\ShapePage.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Controls\DesignGuidance\TypographyControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <Import Project="ContentIncludes.props" />


### PR DESCRIPTION
@gregwoo-microsoft I've made the following changes:

- Moved Typography section to the 'Design Guidance' section in the main menu (probably needs better naming :))
- Created a UserControl to display the typeramps so it's easier to maintain.
- Copy to clipboard works.
- Added XAML sample.

To do:
- Let's discuss what makes sense to highlight with the teaching tips 👍.. maybe moving to tooltips (on hover) is easier to use?
- Nit: SubtleButtonStyle might be useful across the Gallery as well - we could move it to a dedicated Styles file so it's easier to find.


![TypograpghySection](https://user-images.githubusercontent.com/9866362/212696782-2a68155c-5105-4bc4-a860-da250aeb762a.gif)
